### PR TITLE
Cannot able to delete the field in Exploratory testing

### DIFF
--- a/IDE/src/main/java/com/cognizant/cognizantits/ide/main/explorer/settings/SettingsUI.java
+++ b/IDE/src/main/java/com/cognizant/cognizantits/ide/main/explorer/settings/SettingsUI.java
@@ -862,7 +862,10 @@ public class SettingsUI extends javax.swing.JFrame {
     }//GEN-LAST:event_jButton5ActionPerformed
 
     private void jButton6ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton6ActionPerformed
-        conn.DeleteField(moduleList.getSelectedItem().toString(), fieldsTable.getValueAt(fieldsTable.getSelectedRow(), 1).toString());
+        Object rowValue = fieldsTable.getValueAt(fieldsTable.getSelectedRow(), 1);
+        if (rowValue != null) {
+            conn.DeleteField(moduleList.getSelectedItem().toString(), rowValue.toString());
+        }
         JtableUtils.deleterow(fieldsTable);
     }//GEN-LAST:event_jButton6ActionPerformed
 

--- a/IDE/src/main/java/com/cognizant/cognizantits/ide/main/explorer/settings/SettingsUI.java
+++ b/IDE/src/main/java/com/cognizant/cognizantits/ide/main/explorer/settings/SettingsUI.java
@@ -57,6 +57,7 @@ public class SettingsUI extends javax.swing.JFrame {
         updateModuleDropDown();
         TableCheckBoxColumn.installFor(fieldsTable, 0);
         JtableUtils.addlisteners(fieldsTable, true);
+        fieldsTable.getTableHeader().setReorderingAllowed(false);
         JtableUtils.addlisteners(modulesTable, false);
         loadExplorerSettings();
         fieldConfig.setAlwaysOnTop(true);
@@ -861,6 +862,7 @@ public class SettingsUI extends javax.swing.JFrame {
     }//GEN-LAST:event_jButton5ActionPerformed
 
     private void jButton6ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton6ActionPerformed
+        conn.DeleteField(moduleList.getSelectedItem().toString(), fieldsTable.getValueAt(fieldsTable.getSelectedRow(), 2).toString());
         JtableUtils.deleterow(fieldsTable);
     }//GEN-LAST:event_jButton6ActionPerformed
 

--- a/IDE/src/main/java/com/cognizant/cognizantits/ide/main/explorer/settings/SettingsUI.java
+++ b/IDE/src/main/java/com/cognizant/cognizantits/ide/main/explorer/settings/SettingsUI.java
@@ -862,7 +862,7 @@ public class SettingsUI extends javax.swing.JFrame {
     }//GEN-LAST:event_jButton5ActionPerformed
 
     private void jButton6ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton6ActionPerformed
-        conn.DeleteField(moduleList.getSelectedItem().toString(), fieldsTable.getValueAt(fieldsTable.getSelectedRow(), 2).toString());
+        conn.DeleteField(moduleList.getSelectedItem().toString(), fieldsTable.getValueAt(fieldsTable.getSelectedRow(), 1).toString());
         JtableUtils.deleterow(fieldsTable);
     }//GEN-LAST:event_jButton6ActionPerformed
 


### PR DESCRIPTION
While deleting the field from the dialog call "DeleteField" method it takes module name and field name as input. So fetch those values from the combo box and from table. The field header should not be reordered :smile:  so enforced "false" in field table.

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here / explain!)
Refer an issue https://github.com/CognizantQAHub/Cognizant-Intelligent-Test-Scripter/issues/47


* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:


