### PR TITLE
Delete Page from filesystem, when deleted from UI

### DIFF
--- a/Datalib/src/main/java/com/cognizant/cognizantits/datalib/component/utils/FileUtils.java
+++ b/Datalib/src/main/java/com/cognizant/cognizantits/datalib/component/utils/FileUtils.java
@@ -148,7 +148,7 @@ public class FileUtils {
             if (src.exists()) {
                 File target = new File(src.getParent(), toName);
                 if (target.exists()) {
-                    LOGGER.log(Level.WARNING, " target {1} exists failed to rename {1}",
+                    LOGGER.log(Level.INFO, "A File with Name '{1}' already exists, failed to rename '{0}'",
                             new Object[]{fromFile, toName});
                     return false;
                 }

--- a/Datalib/src/main/java/com/cognizant/cognizantits/datalib/or/image/ImageORPage.java
+++ b/Datalib/src/main/java/com/cognizant/cognizantits/datalib/or/image/ImageORPage.java
@@ -94,6 +94,7 @@ public class ImageORPage implements ORPageInf<ImageORObject, ImageOR> {
     public void removeFromParent() {
         root.setSaved(false);
         root.getPages().remove(this);
+        FileUtils.deleteFile(getRepLocation());
     }
 
     @JsonIgnore

--- a/Datalib/src/main/java/com/cognizant/cognizantits/datalib/or/mobile/MobileORPage.java
+++ b/Datalib/src/main/java/com/cognizant/cognizantits/datalib/or/mobile/MobileORPage.java
@@ -94,6 +94,7 @@ public class MobileORPage implements ORPageInf<MobileORObject, MobileOR> {
     public void removeFromParent() {
         root.setSaved(false);
         root.getPages().remove(this);
+        FileUtils.deleteFile(getRepLocation());
     }
 
     @JsonIgnore

--- a/Datalib/src/main/java/com/cognizant/cognizantits/datalib/or/web/WebORPage.java
+++ b/Datalib/src/main/java/com/cognizant/cognizantits/datalib/or/web/WebORPage.java
@@ -96,6 +96,7 @@ public class WebORPage implements ORPageInf<WebORObject, WebOR> {
     public void removeFromParent() {
         root.setSaved(false);
         root.getPages().remove(this);
+        FileUtils.deleteFile(getRepLocation());
     }
 
     @JsonIgnore


### PR DESCRIPTION
Fix for #53

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
    Bug Fix
* **What is the current behavior?** (You can also link to an open issue here / explain!)
     As mentioned in #53 . When Pages are deleted from OR, the respective folders are not deleted from file-system.

* **What is the new behavior (if this is a feature change)?**
     When Pages are deleted from OR, the respective folders are deleted from file-system. Hence avoiding the issue from happening

