### PR TITLE
added `debug` flag cli option for debug-mode

### DIFF
--- a/Engine/src/main/java/com/cognizant/cognizantits/engine/cli/CLI.java
+++ b/Engine/src/main/java/com/cognizant/cognizantits/engine/cli/CLI.java
@@ -36,7 +36,7 @@ import org.json.simple.JSONValue;
 
 /**
  *
- * 
+ *
  */
 public class CLI {
 
@@ -56,9 +56,12 @@ public class CLI {
     }
 
     static void setVar(String val) {
-        String key = val.substring(0, val.indexOf('='));
-        val = val.substring(val.indexOf('=') + 1);
-        SystemDefaults.CLVars.put(key, val);
+        if (val.contains("=")) {
+            String[] vals = val.split("=", 2);
+            SystemDefaults.CLVars.put(vals[0], vals[1]);
+        } else {
+            SystemDefaults.CLVars.put(val, "true");
+        }
     }
 
     static void setEnv(String val) {
@@ -317,5 +320,6 @@ public class CLI {
         public static final String BROWSER_NAME = "browser";
         public static final String VERSION = "version";
         public static final String V = "v";
+        public static final String DEBUG = "debug";
     }
 }

--- a/Engine/src/main/java/com/cognizant/cognizantits/engine/cli/CLI.java
+++ b/Engine/src/main/java/com/cognizant/cognizantits/engine/cli/CLI.java
@@ -61,6 +61,7 @@ public class CLI {
             SystemDefaults.CLVars.put(vals[0], vals[1]);
         } else {
             /*
+            * handle as a flag if it doesn't match key=var
             */
             SystemDefaults.CLVars.put(val, "true");
         }

--- a/Engine/src/main/java/com/cognizant/cognizantits/engine/cli/CLI.java
+++ b/Engine/src/main/java/com/cognizant/cognizantits/engine/cli/CLI.java
@@ -60,6 +60,8 @@ public class CLI {
             String[] vals = val.split("=", 2);
             SystemDefaults.CLVars.put(vals[0], vals[1]);
         } else {
+            /*
+            */
             SystemDefaults.CLVars.put(val, "true");
         }
     }

--- a/Engine/src/main/java/com/cognizant/cognizantits/engine/cli/LookUp.java
+++ b/Engine/src/main/java/com/cognizant/cognizantits/engine/cli/LookUp.java
@@ -29,7 +29,7 @@ import org.apache.commons.cli.ParseException;
 
 /**
  *
- * 
+ *
  */
 public class LookUp {
 
@@ -58,7 +58,7 @@ public class LookUp {
         OPTIONS.addOption(Op.B_TIME, false, "Display current build time");
         OPTIONS.addOption(Op.B_VERSION, false, "Display current build version");
         OPTIONS.addOption(Op.DONT_LAUNCH_SUMMARY, false, "Disables launching summary report after execution");
-        OPTIONS.addOption(Op.DEBUG, false, "Enable debug mode");        
+        OPTIONS.addOption(Op.DEBUG, false, "Enable debug mode");
         OPTIONS.addOption(Op.HELP, false, "Help");
         OPTIONS.addOption(Op.HELLO, false, "Says Hello!");
         OPTIONS.addOption(Op.TIME, false, "Display Current Time");
@@ -118,6 +118,9 @@ public class LookUp {
                         CLI.createStandaloneReport();
                         break;
                     case Op.DEBUG:
+                        /*
+                        * set debug=true
+                         */
                         CLI.setVar(Op.DEBUG);
                         break;
                     case Op.SET_VAR:

--- a/Engine/src/main/java/com/cognizant/cognizantits/engine/cli/LookUp.java
+++ b/Engine/src/main/java/com/cognizant/cognizantits/engine/cli/LookUp.java
@@ -58,6 +58,7 @@ public class LookUp {
         OPTIONS.addOption(Op.B_TIME, false, "Display current build time");
         OPTIONS.addOption(Op.B_VERSION, false, "Display current build version");
         OPTIONS.addOption(Op.DONT_LAUNCH_SUMMARY, false, "Disables launching summary report after execution");
+        OPTIONS.addOption(Op.DEBUG, false, "Enable debug mode");        
         OPTIONS.addOption(Op.HELP, false, "Help");
         OPTIONS.addOption(Op.HELLO, false, "Says Hello!");
         OPTIONS.addOption(Op.TIME, false, "Display Current Time");
@@ -115,6 +116,9 @@ public class LookUp {
                         break;
                     case Op.STANDALONE_REPORT:
                         CLI.createStandaloneReport();
+                        break;
+                    case Op.DEBUG:
+                        CLI.setVar(Op.DEBUG);
                         break;
                     case Op.SET_VAR:
                         CLI.setVar(op.getValue());

--- a/Engine/src/main/java/com/cognizant/cognizantits/engine/constants/SystemDefaults.java
+++ b/Engine/src/main/java/com/cognizant/cognizantits/engine/constants/SystemDefaults.java
@@ -94,4 +94,7 @@ public class SystemDefaults {
         System.out.println(String.format("%-20s : %s", key, System.getProperty(key)));
     }
 
+    public static boolean debug() {
+        return debugMode.get() || Boolean.valueOf(CLVars.get("debug"));
+    }
 }

--- a/Engine/src/main/java/com/cognizant/cognizantits/engine/execution/run/ProjectRunner.java
+++ b/Engine/src/main/java/com/cognizant/cognizantits/engine/execution/run/ProjectRunner.java
@@ -38,7 +38,7 @@ import java.util.logging.Logger;
 
 /**
  *
- * 
+ *
  */
 public class ProjectRunner implements TestRunner {
 
@@ -186,13 +186,13 @@ public class ProjectRunner implements TestRunner {
             }
         }
         /**
-         * update with app CLI's setEnv settings (will override the System
-         * Env)
+         * update with app CLI's setEnv settings (will override the System Env)
          */
 
         prop.putAll(SystemDefaults.EnvVars);
         if (!prop.isEmpty()) {
-            System.out.println("Override with Environment Settings :\n " + prop);
+            System.out.println("Override with Environment Settings :\n "
+                    + (SystemDefaults.debug() ? prop : prop.keySet()));
             /*
              * update the exe/run/user settings with CLI's Env settings
              * (case sensitive)

--- a/Engine/src/main/java/com/cognizant/cognizantits/engine/execution/run/ProjectRunner.java
+++ b/Engine/src/main/java/com/cognizant/cognizantits/engine/execution/run/ProjectRunner.java
@@ -191,8 +191,11 @@ public class ProjectRunner implements TestRunner {
 
         prop.putAll(SystemDefaults.EnvVars);
         if (!prop.isEmpty()) {
+            /*
+            * display entries only if debug flag is set
+            */
             System.out.println("Override with Environment Settings :\n "
-                    + (SystemDefaults.debug() ? prop : prop.keySet()));
+                    + (SystemDefaults.debug() ? prop.entrySet() : prop.keySet()));
             /*
              * update the exe/run/user settings with CLI's Env settings
              * (case sensitive)

--- a/Engine/src/main/java/com/cognizant/cognizantits/engine/support/DLogger.java
+++ b/Engine/src/main/java/com/cognizant/cognizantits/engine/support/DLogger.java
@@ -31,8 +31,7 @@ public class DLogger {
     }
 
     public static boolean debug() {
-        return SystemDefaults.CLVars.containsKey("debug") 
-                || SystemDefaults.debugMode.get();
+        return SystemDefaults.debug(); 
         
     }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added  <!--(for bug fixes / features) -->
- [ ] Docs have been added / updated  <!--(for bug fixes / features) -->


* **What kind of change does this PR introduce?**  <!--(Bug fix, feature, docs update, ...) -->

- added new cli option  `debug` 
- default `debug` state is `false` 
- use of `debug` flag is available by adding `-debug` or `-setVar debug=true` (will set debug `true`)
- print override-able env properties w/ values only when `debug` is set, otherwise print only keys.

* **Use case for changing the behavior**

1. will be useful in masking sensitive data in log, ex. `password/ tokens` can be hidden while using `env` variables and printed in log while debugging  using `debug` flag.
2. detail logs can be enable when needed w/o polluting `console` log

* **Does this PR introduce a breaking change?**  
no


