### PR TITLE
Changed Logic to show window if it is minimized

### DIFF
--- a/IDE/src/main/java/com/cognizant/cognizantits/ide/main/shr/SHR.java
+++ b/IDE/src/main/java/com/cognizant/cognizantits/ide/main/shr/SHR.java
@@ -36,10 +36,7 @@ public class SHR {
 
     private final MobileObjectSpy mobileObjectSpy;
 
-    private final AppMainFrame sMainFrame;
-
     public SHR(AppMainFrame sMainFrame) {
-        this.sMainFrame = sMainFrame;
         objHeal = new ObjectHeal(sMainFrame);
         objSpy = new ObjectSpy(sMainFrame);
         recorder = new Recorder(sMainFrame);
@@ -60,7 +57,7 @@ public class SHR {
             objHeal.closeWindow();
         }
         if (objSpy.isVisible()) {
-            objSpy.toFront();
+            objSpy.setState(ObjectSpy.NORMAL);
         } else {
             objSpy.pack();
             objSpy.setLocation(0, 0);
@@ -76,7 +73,7 @@ public class SHR {
             objSpy.closeWindow();
         }
         if (objHeal.isVisible()) {
-            objHeal.toFront();
+            objHeal.setState(ObjectHeal.NORMAL);
         } else {
             objHeal.pack();
             objHeal.setLocation(0, 0);
@@ -89,7 +86,7 @@ public class SHR {
 
     public void showMobileSpy() {
         if (mobileObjectSpy.isVisible()) {
-            mobileObjectSpy.toFront();
+            mobileObjectSpy.setState(MobileObjectSpy.NORMAL);
         } else {
             mobileObjectSpy.setLocationRelativeTo(null);
             mobileObjectSpy.setLocation(mobileObjectSpy.getLocation().x, 0);
@@ -100,7 +97,7 @@ public class SHR {
 
     public void showImageSpy() {
         if (imageSpy.isVisible()) {
-            imageSpy.toFront();
+            imageSpy.setState(ImageSpy.NORMAL);
         } else {
             imageSpy.showImageSpy();
             imageSpy.toFront();


### PR DESCRIPTION
Replaced .toFront() with setState, as this will bring the window to the front even if it is minimized

Removed unused private member as well

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines

* **What kind of change does this PR introduce?**  <!--(Bug fix, feature, docs update, ...) -->

    Enhancement  

* **What is the current behavior?**  <!--(You can also link to an open issue here / explain!) -->

     Open Object Spy/Heal/Mobile Spy/Image Spy and Minimize it.
     Try to click on respective buttons From Toolbar/Menu in the UI.
     The window won't come to front.

* **What is the new behavior?** <!--(if this is a feature change) -->

     Even if the Window is minimized , On clicking of spy button from toolbar, the window will come to front

* **Does this PR introduce a breaking change?**  <!--(What changes might users need to make in their application due to this PR?)-->

    No
