### PR TITLE
fix(engine): fixes incorrect reusable status on test report

### DIFF
--- a/Engine/src/main/java/com/cognizant/cognizantits/engine/execution/exception/TestFailedException.java
+++ b/Engine/src/main/java/com/cognizant/cognizantits/engine/execution/exception/TestFailedException.java
@@ -15,31 +15,22 @@
  */
 package com.cognizant.cognizantits.engine.execution.exception;
 
-public class ForcedException extends RuntimeException {
+public class TestFailedException extends RuntimeException {
 
-    public String ErrorName;
-    public String ErrorDescription;
+    private String testName;
 
-    public ForcedException(String errorName, String errorDescription) {
-        this.ErrorName = errorName;
-        this.ErrorDescription = errorDescription;
-
-    }
-
-    public ForcedException(String errorName, Throwable ex) {
+    public TestFailedException(String scenario, String testcase, Throwable ex) {
         super(ex);
-        this.ErrorName = errorName;
-        this.ErrorDescription = ex.getMessage();
+        this.testName = String.format("//%s/%s", scenario, testcase);
     }
 
-    public ForcedException(String errorDescription) {
-        this.ErrorName = "ForcedException";
-        this.ErrorDescription = errorDescription;
+    public TestFailedException(String errorDescription, Throwable ex) {
+        super(errorDescription, ex);
     }
 
     @Override
     public String getMessage() {
-        return ErrorDescription;
+        return String.format("Error in testcase [%s]", testName);
     }
 
 }

--- a/Engine/src/main/java/com/cognizant/cognizantits/engine/execution/exception/UnCaughtException.java
+++ b/Engine/src/main/java/com/cognizant/cognizantits/engine/execution/exception/UnCaughtException.java
@@ -15,27 +15,16 @@
  */
 package com.cognizant.cognizantits.engine.execution.exception;
 
-import com.cognizant.cognizantits.engine.reporting.TestCaseReport;
-import com.cognizant.cognizantits.engine.support.Status;
+public class UnCaughtException extends RuntimeException {
 
-public class UnCaughtException extends Exception {
-
-    private static final long serialVersionUID = 1L;
-    public String errorName = "Error";
-
-    public UnCaughtException(String errorDescription, TestCaseReport r) {
-        super(errorDescription);
-        r.updateTestLog("Exception", errorDescription, Status.FAIL);
-    }
-
-    public UnCaughtException(String errorName, String errorDescription, TestCaseReport r) {
-        super(errorDescription);
-        this.errorName = errorName;
-        r.updateTestLog(errorName + " Exception", errorDescription, Status.FAIL);
-    }
+    public String errorName = "UnCaughtException";
 
     public UnCaughtException(String errorDescription) {
         super(errorDescription);
+    }
+
+    public UnCaughtException(Throwable ex) {
+        super(ex);
     }
 
     public UnCaughtException(String errorName, String errorDescription) {


### PR DESCRIPTION

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added 
- [x] Docs have been added / updated 


* **What kind of change does this PR introduce?** 
Bug fix
* **What is the current behavior?**
#62 

* **What is the new behavior?** 
 update the `report` for the failed step first and break the execution by throwing 
 `TestFailedException`

* **Does this PR introduce a breaking change?**  
no

* **Other information**:
 ## checklist
- [ ] `ContinueOnError` not affected
- [ ]  Step fail on `BreakOnError` breaks execution with expected status 
- [ ]  missing  `data` or `reusable` breaks the execution 
- [ ] `DriverClosed` error not affected
