### PR TITLE
Added Headless Chrome, ChromeDriver Update and Fixes

### DIFF
--- a/Engine/src/main/java/com/cognizant/cognizantits/engine/commands/galenCommands/General.java
+++ b/Engine/src/main/java/com/cognizant/cognizantits/engine/commands/galenCommands/General.java
@@ -29,7 +29,7 @@ import org.openqa.selenium.WebElement;
 
 /**
  *
- * 
+ *
  */
 public class General extends Report {
 
@@ -88,11 +88,7 @@ public class General extends Report {
         if (Element != null) {
             elementMap.put(ObjectName, Element);
         }
-        return new PageValidationWrapper(getPage(relativeElement), elementMap);
-    }
-
-    private PageWrapper getPage(RelativeElement relativeElement) {
-        return new PageWrapper(Driver, getRelativeElement(relativeElement));
+        return new PageValidationWrapper(new PageWrapper(Driver, elementMap), elementMap);
     }
 
     public void validate(Spec spec, RelativeElement relativeElement) {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added  <!--(for bug fixes / features) -->
- [ ] Docs have been added / updated  <!--(for bug fixes / features) -->


* **What kind of change does this PR introduce?**  <!--(Bug fix, feature, docs update, ...) -->

    Enhancement, Feature and possible bug fix
 
    Updated ChromeDriver to 2.31

    Added Headless Chrome, a new browser type to execute scripts in Chrome in Headless mode.


* **What is the current behavior?**  <!--(You can also link to an open issue here / explain!) -->

    1. Whenever `WebDriver` object created, It is maximized using `driver.manage().window().maximize()`. It is throwing exceptions for some users incase of ChromeDriver.
    2. When running galen actions the relative element( the one specified in condition field) is found twice. i.e The Element find logic executed twice.

* **What is the new behavior?** <!--(if this is a feature change) -->

   1. Replaced it with ChromeOptions as suggested by the Chromedriver.
   2. Changed the logic to find the Relative Elements one time.

* **Does this PR introduce a breaking change?**  <!--(What changes might users need to make in their application due to this PR?)-->

   No Change.

* **Other information**:

   The Headless chrome will work only from Chrome 60 in Windows and Chrome 59 onwards in Linux and Mac
