### PR TITLE
fix(engine): added `exclude-objects` option fixes #92

### DIFF
--- a/Engine/src/main/java/com/cognizant/cognizantits/engine/galenWrapper/SpecValidation/SpecReader.java
+++ b/Engine/src/main/java/com/cognizant/cognizantits/engine/galenWrapper/SpecValidation/SpecReader.java
@@ -63,13 +63,15 @@ import com.galenframework.specs.SpecWidth;
 import com.galenframework.specs.colors.ColorRange;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 /**
  *
- * 
+ *
  */
 public class SpecReader {
 
@@ -284,11 +286,28 @@ public class SpecReader {
                     case "crop-if-outside":
                         spec.setCropIfOutside(true);
                         break;
+                    case "exclude-objects":
+                        String ignoreObjects = parseExcludeObjects(parameter.getValue());
+                        Optional.ofNullable(spec.getIgnoredObjectExpressions())
+                                .orElseGet(() -> {
+                                    List<String> l = new LinkedList<>();
+                                    spec.setIgnoredObjectExpressions(l);
+                                    return l;
+                                })
+                                .add(ignoreObjects);
+                        break;
                     default:
                         throw new SyntaxException("Unknown parameter: " + parameter.getKey());
                 }
             }
         }
+    }
+
+    private String parseExcludeObjects(String value) {
+        if (value.startsWith("[") && value.endsWith("]")) {
+            return value.substring(1, value.length() - 1);
+        }
+        return value;
     }
 
     private Rect parseRect(String text) {


### PR DESCRIPTION
added `exclude-objects` option to galen image validation
fixes #92

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added  <!--(for bug fixes / features) -->
- [ ] Docs have been added / updated  <!--(for bug fixes / features) -->


* **What kind of change does this PR introduce?**  <!--(Bug fix, feature, docs update, ...) -->
fixes #92


* **What is the current behavior?**  <!--(You can also link to an open issue here / explain!) -->
see #92 


* **What is the new behavior?** <!--(if this is a feature change) -->
galen image validation can exclude part of image using `exclude-objects`


* **Does this PR introduce a breaking change?**  <!--(What changes might users need to make in their application due to this PR?)-->
no


* **Other information**:
usage
assertElementImage	|@exclude-objects  [excludeobject]
assertElementImage	|@exclude-objects  excludeobject
assertElementImage	|@exclude-objects  [excludeobject,excludeobject2]


